### PR TITLE
Fixed add-path deprecation warnings

### DIFF
--- a/.github/workflows/depup.yml
+++ b/.github/workflows/depup.yml
@@ -19,7 +19,7 @@ jobs:
           repo: reviewdog/reviewdog
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v2
+        uses: peter-evans/create-pull-request@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           title: "chore(deps): update reviewdog to ${{ steps.depup.outputs.latest }}"

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           mkdir -p $HOME/bin
           curl -sfL https://install.goreleaser.com/github.com/mvdan/sh.sh | sh -s -- -b $HOME/bin
-          echo ::add-path::$HOME/bin
+          echo $HOME/bin >> $GITHUB_PATH
 
       - run: shfmt -i 2 -ci -w .
       - name: suggester / shfmt

--- a/install.sh
+++ b/install.sh
@@ -23,4 +23,4 @@ echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/review
 curl -sfL "${INSTALL_SCRIPT}" | sh -s -- -b "${TEMP}/reviewdog/bin" "${VERSION}" 2>&1
 echo '::endgroup::'
 
-echo "::add-path::${TEMP}/reviewdog/bin"
+echo "${TEMP}/reviewdog/bin" >>"${GITHUB_PATH}"


### PR DESCRIPTION
Using this action results in the `::add-path::` deprecation warnings as described in [the GitHub blog](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/). These deprecation warnings are also visible in the ran actions of this repo itself. 

This PR is intended to fix this by using the new syntax and updating the [create-pull-request](https://github.com/peter-evans/create-pull-request) dependency.