### PR TITLE
fix installing shfmt

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -29,10 +29,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: install mvdan/sh
         run: |
-          mkdir -p $HOME/bin
-          curl -sfL https://install.goreleaser.com/github.com/mvdan/sh.sh | sh -s -- -b $HOME/bin
-          echo $HOME/bin >> $GITHUB_PATH
-
+          shfmtversion="v3.6.0"
+          wget -q https://github.com/mvdan/sh/releases/download/${shfmtversion?}/shfmt_${shfmtversion?}_linux_amd64
+          sudo install shfmt_${shfmtversion?}_linux_amd64 /usr/local/bin/shfmt
+          rm shfmt_${shfmtversion?}_linux_amd64
       - run: shfmt -i 2 -ci -w .
       - name: suggester / shfmt
         uses: reviewdog/action-suggester@master


### PR DESCRIPTION
`install.goreleaser.com` is no longer available.
we use wget command instead.