### PR TITLE
Update test case reviewdog version to work with Apple Silicon Mac runner

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,8 +26,8 @@ jobs:
       - name: install reviewdog (with reviewdog_version)
         uses: ./
         with:
-          reviewdog_version: v0.10.0
-      - run: test "$(reviewdog -version)" = '0.10.0'
+          reviewdog_version: v0.17.4
+      - run: test "$(reviewdog -version)" = '0.17.4'
 
   container:
     runs-on: ubuntu-latest


### PR DESCRIPTION
- After #37 merged, test on MacOS fail: https://github.com/reviewdog/action-setup/actions/runs/8920194187/job/24497759111
- It comes from `macos-latest` GitHub runner is currently Apple Silicon (ref: https://github.com/actions/runner-images)
- In this test case, we use [reviewdog v0.10.0](https://github.com/reviewdog/reviewdog/releases/tag/v0.10.0) & It does not release `Darwin/arm64` binary